### PR TITLE
Fix handling of responses where content is `bytes`

### DIFF
--- a/src/debug_toolbar_force/middleware.py
+++ b/src/debug_toolbar_force/middleware.py
@@ -2,9 +2,9 @@ import json
 
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import  smart_text
 
 from nine.versions import DJANGO_GTE_1_10
-from six import text_type
 
 from .settings import GET_PARAM_NAME_FORCE, GET_PARAM_NAME_NON_AJAX
 
@@ -60,13 +60,8 @@ class ForceDebugToolbarMiddleware(object):
                                         len(response.content))
                 response = HttpResponse(new_content)
             elif response['Content-Type'] != 'text/html':
-                content = response.content
-                try:
-                    json_ = json.loads(text_type(content))
-                    content = json.dumps(json_, sort_keys=True, indent=2)
-                except ValueError:
-                    pass
-                response = HttpResponse('<html><body>{}'
-                                        '</body></html>'.format(content))
+                content = smart_text(response.content)
+                response = HttpResponse(u'<html><body>{}'
+                                        u'</body></html>'.format(content))
 
         return response

--- a/src/debug_toolbar_force/tests/foo/urls.py
+++ b/src/debug_toolbar_force/tests/foo/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from .views import (
     ajax_view,
     json_view,
+    json_bytes_view,
     html_view,
     partial_html_view
 )
@@ -17,6 +18,7 @@ __all__ = ('urlpatterns',)
 urlpatterns = [
     url(r'^ajax-view/$', view=ajax_view, name='foo.ajax_view'),
     url(r'^json-view/$', view=json_view, name='foo.json_view'),
+    url(r'^json-bytes-view/$', view=json_bytes_view, name='foo.json_bytes_view'),
     url(r'^html-view/$', view=html_view, name='foo.html_view'),
     url(r'^partial-html-view/$',
         view=partial_html_view,

--- a/src/debug_toolbar_force/tests/foo/views.py
+++ b/src/debug_toolbar_force/tests/foo/views.py
@@ -1,7 +1,7 @@
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render
 
-from six import text_type
+import json
 
 __title__ = 'debug_toolbar_force.tests.foo.views'
 __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'
@@ -17,8 +17,13 @@ __all__ = (
 
 def json_view(request):
     """JSON view."""
-    return JsonResponse(text_type([1, 2, 3]), safe=False)
+    # Standard Django way, content will be unicode
+    return JsonResponse([1, 2, 3], safe=False)
 
+def json_bytes_view(request):
+    """JSON view, returns bytes"""
+    # Something an application may do is return bytes instead of unicode
+    return HttpResponse(json.dumps([1, 2, 3]), content_type="application/json")
 
 def ajax_view(request, template_name='foo/ajax_view.html'):
     """AJAX view."""


### PR DESCRIPTION
This ensures responses with bytes content is handled correctly.